### PR TITLE
[FIX] 플레이어 사망 후 스폰처리

### DIFF
--- a/HCDProject/Assets/Prefabs/MonsterPrefab/MonsterID1.prefab
+++ b/HCDProject/Assets/Prefabs/MonsterPrefab/MonsterID1.prefab
@@ -173,10 +173,10 @@ MonoBehaviour:
     _attackRange: 1
     _chaseRange: 3
   skills:
-  - skillDamage: 0
+  - skillDamage: 50
     skillRange: 1
     coolTime: 2
-    targetCount: 0
+    targetCount: 1
     TargetType: 0
   EnemyFilter:
     useTriggers: 0
@@ -210,7 +210,7 @@ MonoBehaviour:
     MONSTER_ID: 
     MONSTER_NAME: 
     HP: 0
-    ATK: 0
+    ATK: 200
     DEF: 0
     ATK_SPEED: 0
     MOVE_SPEED: 0

--- a/HCDProject/Assets/Scripts/Core/Manager/PlayerManager.cs
+++ b/HCDProject/Assets/Scripts/Core/Manager/PlayerManager.cs
@@ -56,6 +56,7 @@ public class PlayerManager : BaseManager<PlayerManager>
             BaseCharacter chr = obj.GetComponent<BaseCharacter>();
 
             chr.homePosition = _homePoints[i].position;
+            chr.spawnPosition = _spawnPoints[i].position;
             chr.Init(_characterDatas[i]);
             _characters[i] = chr;
             Debug.Log($"{i}번 플레이어 생성 완료");

--- a/HCDProject/Assets/Scripts/NPC/Player/BaseCharacter.cs
+++ b/HCDProject/Assets/Scripts/NPC/Player/BaseCharacter.cs
@@ -18,6 +18,7 @@ public class BaseCharacter : BaseController
     private DiePlayerState _diePlayerState;
 
     [SerializeField]private Vector3 _homePosition; // 지정된 위치
+    [SerializeField] private Vector3 _spawnPosition; // 스폰 및 부활
 
     private int _skillTargetIndex; // 지정된 타겟에 대한 스킬 인덱스
 
@@ -97,6 +98,12 @@ public class BaseCharacter : BaseController
             state.ChangeState(this.chase);
         }
 
+    }
+
+    public Vector3 spawnPosition
+    {
+        get => _spawnPosition;
+        set => _spawnPosition = value;
     }
 
     public Vector3 homePosition
@@ -251,9 +258,12 @@ public class BaseCharacter : BaseController
     {
         _isDead = false;
         _isSpawning = true;
+        this.Movement.Agent.Warp(spawnPosition);
         CurrentHp.Value = Stats._maxHp;
 
         _isFirstCombat = _baseData._hasFirstCombat;
+        Debug.Log($"before: {_findType}");
         _findType = _baseData._initFindType;
+        Debug.Log($"after: {_findType}");
     }
 }

--- a/HCDProject/Assets/Scripts/NPC/Player/PlayerState/DiePlayerState.cs
+++ b/HCDProject/Assets/Scripts/NPC/Player/PlayerState/DiePlayerState.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.AI;
 
 public class DiePlayerState : IState
 {
@@ -13,7 +14,10 @@ public class DiePlayerState : IState
 
     public void Enter()
     {
-        _owner.Movement.Stop();
+        if (_owner.Movement.Agent.isOnNavMesh)
+        {
+            _owner.Movement.Stop();
+        }
         _owner.gameObject.SetActive(false);
         Service.Get<PlayerManager>()?.StartRevive(_owner);
     }

--- a/HCDProject/Assets/Scripts/SO/Warrior_BaseData.asset
+++ b/HCDProject/Assets/Scripts/SO/Warrior_BaseData.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   _moveSpeed: 2
   _attackRange: 2
   _chaseRange: 4
-  _initFindType: 0
+  _initFindType: 1
   _hasFirstCombat: 1
   _attackSpeed: 0.75
   _critRate: 0.05


### PR DESCRIPTION
기존 플레이어가 사망 후 배치된 포지션에서 부활하는 버그 발생

- 플레이어 매니저에서 스폰 포인트를 초기화 해줌
- 테스트 후 스폰포인트에서 부활 확인